### PR TITLE
Fix empty GeoJSON handling

### DIFF
--- a/geojson_mapper/callbacks.py
+++ b/geojson_mapper/callbacks.py
@@ -71,6 +71,15 @@ def register_callbacks(app):
             longitudes.extend([bounds[0], bounds[2]])
             latitudes.extend([bounds[1], bounds[3]])
         
+
+        if not centroids:
+            return (
+                f"No features found in {filename}.",
+                no_update,
+                no_update,
+                no_update,
+            )
+
         avg_lat = sum(centroid.y for centroid in centroids) / len(centroids)
         avg_lon = sum(centroid.x for centroid in centroids) / len(centroids)
         

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,28 @@
+import base64
+import json
+import dash
+from dash import no_update
+
+import geojson_mapper.callbacks as cb
+
+
+def get_update_map_function():
+    app = dash.Dash(__name__)
+    cb.register_callbacks(app)
+    # Extract the original callback function from the map
+    callback_fn = next(iter(app.callback_map.values()))['callback'].__wrapped__
+    return callback_fn
+
+
+def test_update_map_with_empty_features():
+    update_map = get_update_map_function()
+    empty_geojson = {"type": "FeatureCollection", "features": []}
+    contents = "data:application/json;base64," + base64.b64encode(
+        json.dumps(empty_geojson).encode()
+    ).decode()
+    message, layer, center, zoom = update_map(contents, "empty.geojson")
+
+    assert "No features" in message
+    assert layer is no_update
+    assert center is no_update
+    assert zoom is no_update


### PR DESCRIPTION
## Summary
- avoid ZeroDivisionError when uploaded GeoJSON has no features
- return message and no_update when features list is empty
- add regression test for this scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d9a819bc8332b2a2f7b080c90904