### PR TITLE
Add fixtures and callback tests

### DIFF
--- a/geojson_mapper/callbacks.py
+++ b/geojson_mapper/callbacks.py
@@ -48,28 +48,34 @@ def register_callbacks(app):
         longitudes = []
         
         for feature in geojson['features']:
-            if 'description' in feature['properties']:
-                feature_component = dl.GeoJSON(
-                    data=feature,
-                    children=dl.Tooltip(content=feature['properties']['description'])
+            try:
+                if 'description' in feature['properties']:
+                    feature_component = dl.GeoJSON(
+                        data=feature,
+                        children=dl.Tooltip(content=feature['properties']['description'])
+                    )
+                else:
+                    feature_component = dl.GeoJSON(
+                        data=feature
+                    )
+                if 'icon' in feature['properties']:
+                    feature_component = dl.Marker(
+                        position=[feature['geometry']['coordinates'][1], feature['geometry']['coordinates'][0]],
+                        children=[
+                            dl.Tooltip(content=feature['properties']['name']),
+                            dl.Popup(content=feature['properties']['description'])
+                        ],
+                        icon=feature['properties']['icon']
+                    )
+                geojson_layer.append(feature_component)
+                geom = shape(feature['geometry'])
+            except Exception as e:
+                return (
+                    f"Error processing {filename}: {str(e)}",
+                    no_update,
+                    no_update,
+                    no_update,
                 )
-            else:
-                feature_component = dl.GeoJSON(
-                    data=feature
-                )
-            if 'icon' in feature['properties']:
-                feature_component = dl.Marker(
-                    position=[feature['geometry']['coordinates'][1], feature['geometry']['coordinates'][0]],
-                    children=[
-                        dl.Tooltip(content=feature['properties']['name']),
-                        dl.Popup(content=feature['properties']['description'])
-                    ],
-                    icon=feature['properties']['icon']
-                )
-            geojson_layer.append(
-                feature_component
-            )
-            geom = shape(feature['geometry'])
             centroids.append(geom.centroid)
             bounds = geom.bounds
             longitudes.extend([bounds[0], bounds[2]])

--- a/tests/fixtures/sample_point.geojson
+++ b/tests/fixtures/sample_point.geojson
@@ -1,0 +1,10 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Sample Point"},
+      "geometry": {"type": "Point", "coordinates": [10.0, 20.0]}
+    }
+  ]
+}

--- a/tests/fixtures/sample_polygon.geojson
+++ b/tests/fixtures/sample_polygon.geojson
@@ -1,0 +1,13 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Sample Polygon"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[0,0],[0,1],[1,1],[1,0],[0,0]]]
+      }
+    }
+  ]
+}

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,5 +1,6 @@
 import json
 import base64
+from pathlib import Path
 import dash
 from dash import no_update
 from geojson_mapper.callbacks import register_callbacks
@@ -14,13 +15,88 @@ def get_update_map(app):
     return callback_data['callback'].__wrapped__
 
 
+def encode_geojson(path: Path) -> str:
+    data = path.read_text()
+    encoded = base64.b64encode(data.encode()).decode()
+    return f"data:application/json;base64,{encoded}"
+
+
 def test_update_map_empty_features():
     app = dash.Dash(__name__)
     update_map = get_update_map(app)
     empty_geojson = {"type": "FeatureCollection", "features": []}
     encoded = base64.b64encode(json.dumps(empty_geojson).encode()).decode()
     contents = f"data:application/json;base64,{encoded}"
-    # simulate dash callback context with test_request_context
     with app.server.test_request_context('/'):
         result = update_map(contents, "empty.geojson")
     assert result == (no_update, no_update, no_update, no_update)
+
+
+def test_update_map_valid_point():
+    app = dash.Dash(__name__)
+    update_map = get_update_map(app)
+    point_path = Path("tests/fixtures/sample_point.geojson")
+    contents = encode_geojson(point_path)
+    with app.server.test_request_context('/'):
+        message, layer, center, zoom = update_map(contents, point_path.name)
+    assert message == f"Successfully uploaded {point_path.name}"
+    assert len(layer) == 1
+    assert center == [20.0, 10.0]
+    assert zoom is no_update
+
+
+def test_update_map_valid_polygon():
+    app = dash.Dash(__name__)
+    update_map = get_update_map(app)
+    poly_path = Path("tests/fixtures/sample_polygon.geojson")
+    contents = encode_geojson(poly_path)
+    with app.server.test_request_context('/'):
+        message, layer, center, zoom = update_map(contents, poly_path.name)
+    assert message == f"Successfully uploaded {poly_path.name}"
+    assert len(layer) == 1
+    assert center == [0.5, 0.5]
+    assert zoom is no_update
+
+
+def test_update_map_malformed_json():
+    app = dash.Dash(__name__)
+    update_map = get_update_map(app)
+    malformed = base64.b64encode(b"{bad json").decode()
+    contents = f"data:application/json;base64,{malformed}"
+    with app.server.test_request_context('/'):
+        message, layer, center, zoom = update_map(contents, "malformed.geojson")
+    assert message.startswith("Error processing malformed.geojson:")
+    assert layer is no_update
+    assert center is no_update
+    assert zoom is no_update
+
+
+def test_update_map_missing_features():
+    app = dash.Dash(__name__)
+    update_map = get_update_map(app)
+    data = {"type": "FeatureCollection"}
+    encoded = base64.b64encode(json.dumps(data).encode()).decode()
+    contents = f"data:application/json;base64,{encoded}"
+    with app.server.test_request_context('/'):
+        message, layer, center, zoom = update_map(contents, "missing.geojson")
+    assert message == "File missing.geojson is not a valid GeoJSON file."
+    assert layer is no_update
+    assert center is no_update
+    assert zoom is no_update
+
+
+def test_update_map_bad_geometry():
+    app = dash.Dash(__name__)
+    update_map = get_update_map(app)
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [10]}}]
+    }
+    encoded = base64.b64encode(json.dumps(geojson).encode()).decode()
+    contents = f"data:application/json;base64,{encoded}"
+    with app.server.test_request_context('/'):
+        message, layer, center, zoom = update_map(contents, "bad.geojson")
+    assert message.startswith("Error processing bad.geojson:")
+    assert layer is no_update
+    assert center is no_update
+    assert zoom is no_update


### PR DESCRIPTION
## Summary
- include a simple point and polygon GeoJSON fixture
- catch geometry parsing errors in `update_map`
- test successful uploads using fixtures
- test error handling for malformed JSON, missing `features`, and bad geometry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e449a9b08332af5cf3b3e6bf515b