### PR TITLE
Enable multiple uploads with layer persistence

### DIFF
--- a/geojson_mapper/callbacks.py
+++ b/geojson_mapper/callbacks.py
@@ -11,43 +11,67 @@ import math
 def register_callbacks(app):
     
     @app.callback(
-        [Output('upload-data', 'children'), Output('geojson-layer', 'children'), Output('map', 'center'), Output('map', 'zoom')],
+        [
+            Output('upload-data', 'children'),
+            Output('geojson-layer', 'children'),
+            Output('map', 'center'),
+            Output('map', 'zoom'),
+            Output('layers-store', 'data'),
+        ],
         [Input('upload-data', 'contents')],
-        [State('upload-data', 'filename')]
+        [State('upload-data', 'filename'), State('layers-store', 'data')]
     )
-    def update_map(contents, filename):
+    def update_map(contents, filename, stored_layers):
         if contents is None:
-            return no_update, no_update, no_update, no_update
+            return no_update, no_update, no_update, no_update, no_update
 
-        content_type, content_string = contents.split(',')
-        try:
-            decoded = base64.b64decode(content_string)
-            geojson = json.loads(decoded)
-            if 'features' not in geojson:
+        stored_layers = stored_layers or []
+
+        if not isinstance(contents, list):
+            contents = [contents]
+        if not isinstance(filename, list):
+            filename = [filename]
+
+        new_features = []
+
+        for cont, fname in zip(contents, filename):
+            content_type, content_string = cont.split(',')
+            try:
+                decoded = base64.b64decode(content_string)
+                geojson = json.loads(decoded)
+                if 'features' not in geojson:
+                    return (
+                        f"File {fname} is not a valid GeoJSON file.",
+                        no_update,
+                        no_update,
+                        no_update,
+                        no_update,
+                    )
+            except Exception as e:
                 return (
-                    f"File {filename} is not a valid GeoJSON file.",
+                    f"Error processing {fname}: {str(e)}",
+                    no_update,
                     no_update,
                     no_update,
                     no_update,
                 )
-        except Exception as e:
-            return (
-                f"Error processing {filename}: {str(e)}",
-                no_update,
-                no_update,
-                no_update,
-            )
-    
-        # Return early if the features list is empty
-        if not geojson.get('features'):
-            return no_update, no_update, no_update, no_update
+
+            if not geojson.get('features'):
+                continue
+
+            new_features.extend(geojson['features'])
+
+        if not new_features:
+            return no_update, no_update, no_update, no_update, no_update
+
+        updated_features = stored_layers + new_features
 
         geojson_layer = []
         centroids = []
         latitudes = []
         longitudes = []
-        
-        for feature in geojson['features']:
+
+        for feature in updated_features:
             if 'description' in feature['properties']:
                 feature_component = dl.GeoJSON(
                     data=feature,
@@ -61,21 +85,40 @@ def register_callbacks(app):
                 feature_component = dl.Marker(
                     position=[feature['geometry']['coordinates'][1], feature['geometry']['coordinates'][0]],
                     children=[
-                        dl.Tooltip(content=feature['properties']['name']),
-                        dl.Popup(content=feature['properties']['description'])
+                        dl.Tooltip(content=feature['properties'].get('name')),
+                        dl.Popup(content=feature['properties'].get('description'))
                     ],
-                    icon=feature['properties']['icon']
+                    icon=feature['properties']['icon'],
                 )
             geojson_layer.append(
                 feature_component
             )
+
+        for feature in new_features:
             geom = shape(feature['geometry'])
             centroids.append(geom.centroid)
             bounds = geom.bounds
             longitudes.extend([bounds[0], bounds[2]])
             latitudes.extend([bounds[1], bounds[3]])
-        
+
         avg_lat = sum(centroid.y for centroid in centroids) / len(centroids)
         avg_lon = sum(centroid.x for centroid in centroids) / len(centroids)
-        
-        return f"Successfully uploaded {filename}", geojson_layer, [avg_lat, avg_lon], no_update
+
+        filenames_str = ', '.join(filename)
+
+        return (
+            f"Successfully uploaded {filenames_str}",
+            geojson_layer,
+            [avg_lat, avg_lon],
+            no_update,
+            updated_features,
+        )
+
+    @app.callback(
+        [Output('geojson-layer', 'children'), Output('layers-store', 'data')],
+        Input('clear-map', 'n_clicks'),
+    )
+    def clear_map(n_clicks):
+        if not n_clicks:
+            return no_update, no_update
+        return [], []

--- a/geojson_mapper/layout.py
+++ b/geojson_mapper/layout.py
@@ -8,6 +8,7 @@ def create_layout():
     return dbc.Container([
         dbc.Row([
             dbc.Col([
+                dcc.Store(id='layers-store', data=[]),
                 dcc.Upload(
                     id='upload-data',
                     children='Drag and Drop or Click to Select a File',
@@ -21,8 +22,9 @@ def create_layout():
                         'textAlign': 'center',
                         'margin': '10px'
                     },
-                    multiple=False
+                    multiple=True
                 ),
+                html.Button('Clear Map', id='clear-map', n_clicks=0),
                 dl.Map(id='map', style={'width': '100%', 'height': '750px'}, center=[37.0902, -95.7129], zoom=4, children=[
                     dl.TileLayer(),
                     dl.LayerGroup(id='geojson-layer')

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,22 +5,44 @@ from dash import no_update
 from geojson_mapper.callbacks import register_callbacks
 
 
-def get_update_map(app):
-    # register_callbacks adds the callback function to the app and returns nothing.
+def setup_app():
+    app = dash.Dash(__name__)
     register_callbacks(app)
-    # Retrieve the first registered callback function
-    callback_data = next(iter(app.callback_map.values()))
-    # Dash wraps the function; __wrapped__ gives the original user function
-    return callback_data['callback'].__wrapped__
+    callbacks = {}
+    for data in app.callback_map.values():
+        func = data['callback'].__wrapped__
+        callbacks[func.__name__] = func
+    return app, callbacks
 
 
 def test_update_map_empty_features():
-    app = dash.Dash(__name__)
-    update_map = get_update_map(app)
+    app, cbs = setup_app()
+    update_map = cbs['update_map']
     empty_geojson = {"type": "FeatureCollection", "features": []}
     encoded = base64.b64encode(json.dumps(empty_geojson).encode()).decode()
     contents = f"data:application/json;base64,{encoded}"
-    # simulate dash callback context with test_request_context
     with app.server.test_request_context('/'):
-        result = update_map(contents, "empty.geojson")
-    assert result == (no_update, no_update, no_update, no_update)
+        result = update_map(contents, "empty.geojson", [])
+    assert result == (no_update, no_update, no_update, no_update, no_update)
+
+
+def test_update_map_multiple_uploads():
+    app, cbs = setup_app()
+    update_map = cbs['update_map']
+    g1 = {"type": "FeatureCollection", "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]}, "properties": {}}]}
+    g2 = {"type": "FeatureCollection", "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 1]}, "properties": {}}]}
+    c1 = f"data:application/json;base64,{base64.b64encode(json.dumps(g1).encode()).decode()}"
+    c2 = f"data:application/json;base64,{base64.b64encode(json.dumps(g2).encode()).decode()}"
+    with app.server.test_request_context('/'):
+        result = update_map([c1, c2], ["a.geojson", "b.geojson"], [])
+    layers = result[4]
+    assert len(layers) == 2
+    assert len(result[1]) == 2
+
+
+def test_clear_map():
+    app, cbs = setup_app()
+    clear_map = cbs['clear_map']
+    with app.server.test_request_context('/'):
+        result = clear_map(1)
+    assert result == ([], [])


### PR DESCRIPTION
## Summary
- allow multiple file uploads
- persist uploaded layers in `dcc.Store` and append new layers to the map
- add button to clear all map layers
- test multiple uploads and map clearing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e437f22483329c8f01ce57a2453b